### PR TITLE
update `app.yaml` and `wasmer.toml`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,4 +53,4 @@ jobs:
 
       # Publish to wasix.org
       - name: Publish
-        run: wasmer deploy --publish-package --registry https://registry.wasmer.io/graphql --token=${{ secrets.WASMER_CIUSER_PROD_TOKEN }}
+        run: wasmer deploy --publish-package --non-interactive --registry https://registry.wasmer.io/graphql --token=${{ secrets.WASMER_CIUSER_PROD_TOKEN }}

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,7 @@
----
 kind: wasmer.io/App.v0
 name: wasix-docs
-app_id: da_DR9EIBt1UlJR
-package: wasmer/wasix-docs@0.60.0
+owner: wasmer
+package: .
+app_id: da_K6AIot5UVLy2
+domains:
+  - wasmer--wasix-docs.wasmer.app

--- a/wasmer.toml
+++ b/wasmer.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasmer/wasix-docs"
-version = "0.60.0"
+version = "0.84.1"
 description = "Documentation for WASIX"
 
 [dependencies]
-"sharrattj/static-web-server" = "1"
+"sharrattj/static-web-server" = "^1"
 
 [fs]
 public = "release"


### PR DESCRIPTION
- make domain used by wasix.org explicit
- use `.` package in app.yaml
- bump package version in wasmer.toml
- non-interactively deploy to wasmer.io from the CI