### PR TITLE
update wasmer version in GH workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v2
-        with:
-          version: "v4.0.0"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
use the latest version of wasmer to deploy the wasix.org app.